### PR TITLE
feat (api): add replicas count and default min/max values

### DIFF
--- a/api/v0beta0/azuredevops_types.go
+++ b/api/v0beta0/azuredevops_types.go
@@ -93,6 +93,10 @@ type AzureDevOpsStatus struct {
 	// +optional
 	DesiredAgents int32 `json:"desiredAgents,omitempty"`
 
+	// DesiredAgents represents the number of agents the controller wants to have
+	// +optional
+	ReadyAgents int32 `json:"readyAgents,omitempty"`
+
 	// LastScalingTime is the last time the number of agents was changed
 	// +optional
 	LastScalingTime *metav1.Time `json:"lastScalingTime,omitempty"`

--- a/api/v0beta0/azuredevops_types.go
+++ b/api/v0beta0/azuredevops_types.go
@@ -60,11 +60,11 @@ type AzureDevOpsSpec struct {
 
 	// MinReplicas is the minimum number of replicas for the agent (default: 1)
 	// +kubebuilder:validation:Optional
-	MinReplicas string `json:"minReplicas,omitempty"`
+	MinReplicas int32 `json:"minReplicas,omitempty"`
 
 	// MaxReplicas is the maximum number of replicas for the agent (default: 10)
 	// +kubebuilder:validation:Optional
-	MaxReplicas string `json:"maxReplicas,omitempty"`
+	MaxReplicas int32 `json:"maxReplicas,omitempty"`
 
 	// Docker specifies Docker-related configuration (Possible values: dind, buildkit)
 	// +kubebuilder:validation:Optional

--- a/api/v0beta0/azuredevops_types.go
+++ b/api/v0beta0/azuredevops_types.go
@@ -58,6 +58,14 @@ type AzureDevOpsSpec struct {
 	// +kubebuilder:validation:Optional
 	Mode string `json:"mode,omitempty"`
 
+	// MinReplicas is the minimum number of replicas for the agent (default: 1)
+	// +kubebuilder:validation:Optional
+	MinReplicas string `json:"minReplicas,omitempty"`
+
+	// MaxReplicas is the maximum number of replicas for the agent (default: 10)
+	// +kubebuilder:validation:Optional
+	MaxReplicas string `json:"maxReplicas,omitempty"`
+
 	// Docker specifies Docker-related configuration (Possible values: dind, buildkit)
 	// +kubebuilder:validation:Optional
 	Docker string `json:"docker,omitempty"`

--- a/config/crd/bases/agents.fr.simplified_azuredevops.yaml
+++ b/config/crd/bases/agents.fr.simplified_azuredevops.yaml
@@ -986,6 +986,16 @@ spec:
                 description: ImagePullSecretRef is the name of the secret used for
                   pulling the agent image
                 type: string
+              maxReplicas:
+                description: 'MaxReplicas is the maximum number of replicas for the
+                  agent (default: 10)'
+                format: int32
+                type: integer
+              minReplicas:
+                description: 'MinReplicas is the minimum number of replicas for the
+                  agent (default: 1)'
+                format: int32
+                type: integer
               mode:
                 description: Mode defines the operational mode of the agent (e.g.,
                   deployment, service)

--- a/config/crd/bases/agents.fr.simplified_azuredevops.yaml
+++ b/config/crd/bases/agents.fr.simplified_azuredevops.yaml
@@ -1204,6 +1204,11 @@ spec:
                   in the pool
                 format: int32
                 type: integer
+              readyAgents:
+                description: DesiredAgents represents the number of agents the controller
+                  wants to have
+                format: int32
+                type: integer
             type: object
         type: object
     served: true

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: simplifiedreg.azurecr.io/azdo-operator
-  newTag: 0.0.3
+  newName: ghcr.io/simplifi-ed/azure-devops-operator
+  newTag: v0.0.1-rc8

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -994,6 +994,16 @@ spec:
                 description: ImagePullSecretRef is the name of the secret used for
                   pulling the agent image
                 type: string
+              maxReplicas:
+                description: 'MaxReplicas is the maximum number of replicas for the
+                  agent (default: 10)'
+                format: int32
+                type: integer
+              minReplicas:
+                description: 'MinReplicas is the minimum number of replicas for the
+                  agent (default: 1)'
+                format: int32
+                type: integer
               mode:
                 description: Mode defines the operational mode of the agent (e.g.,
                   deployment, service)
@@ -1200,6 +1210,11 @@ spec:
               queuedJobs:
                 description: QueuedJobs represents the number of jobs currently queued
                   in the pool
+                format: int32
+                type: integer
+              readyAgents:
+                description: DesiredAgents represents the number of agents the controller
+                  wants to have
                 format: int32
                 type: integer
             type: object
@@ -1522,7 +1537,7 @@ spec:
         - --health-probe-bind-address=:8081
         command:
         - /manager
-        image: simplifiedreg.azurecr.io/azdo-operator:0.0.3
+        image: ghcr.io/simplifi-ed/azure-devops-operator:v0.0.1-rc8
         livenessProbe:
           httpGet:
             path: /healthz

--- a/internal/app/usecase/reconcile.go
+++ b/internal/app/usecase/reconcile.go
@@ -56,6 +56,7 @@ func (r *Reconcile) Handle(ctx context.Context, azdo *v0beta0.AzureDevOps) (ctrl
 	// Update status
 	azdo.Status.QueuedJobs = int32(queueLength)
 	azdo.Status.DesiredAgents = desiredReplicas
+	azdo.Status.ReadyAgents = currentReplicas
 
 	// Only update LastScalingTime if replica count changes
 	if currentReplicas != desiredReplicas {

--- a/internal/app/usecase/reconcile.go
+++ b/internal/app/usecase/reconcile.go
@@ -80,22 +80,15 @@ func (r *Reconcile) Handle(ctx context.Context, azdo *v0beta0.AzureDevOps) (ctrl
 // determineDesiredReplicas calculates the number of replicas based on queue length
 func determineDesiredReplicas(queueLength int, logger logr.Logger, azdo *v0beta0.AzureDevOps) int32 {
 	// Determine min and max replicas from spec or use defaults
-	minReplicas := int32(1)  // default value in API type
-	maxReplicas := int32(10) // default value in API type
+	minReplicas := int32(1)
+	maxReplicas := int32(10)
 
 	// Parse spec values if defined
 	if azdo.Spec.MinReplicas > 0 {
 		minReplicas = azdo.Spec.MinReplicas
-		logger.V(1).Info("Using spec minReplicas", "value", minReplicas)
-	} else {
-		logger.V(1).Info("Using default minReplicas", "default", minReplicas)
 	}
-
 	if azdo.Spec.MaxReplicas > 0 {
 		maxReplicas = azdo.Spec.MaxReplicas
-		logger.V(1).Info("Using spec maxReplicas", "value", maxReplicas)
-	} else {
-		logger.V(1).Info("Using default maxReplicas", "default", maxReplicas)
 	}
 
 	if minReplicas > maxReplicas {
@@ -103,22 +96,19 @@ func determineDesiredReplicas(queueLength int, logger logr.Logger, azdo *v0beta0
 			"minReplicas", minReplicas, "maxReplicas", maxReplicas)
 		minReplicas, maxReplicas = maxReplicas, minReplicas
 	}
-	// If there are no jobs in queue, scale to minimum
+
 	if queueLength == 0 {
-		logger.V(1).Info("No jobs in queue, scaling to minimum", "min", minReplicas)
 		return minReplicas
 	}
 
-	// Calculate desired replicas with bounds
-	desired := int32((queueLength + jobsPerReplica - 1) / jobsPerReplica) // Ceiling division
+	desired := int32((queueLength + jobsPerReplica - 1) / jobsPerReplica)
 
-	// Ensure desired is within bounds
 	if desired < minReplicas {
 		desired = minReplicas
 	}
 	if desired > maxReplicas {
 		desired = maxReplicas
-		logger.Info("Queue length exceeds capacity",
+		logger.V(1).Info("Queue length exceeds capacity",
 			"queueLength", queueLength,
 			"maxReplicas", maxReplicas)
 	}

--- a/internal/app/usecase/reconcile.go
+++ b/internal/app/usecase/reconcile.go
@@ -3,7 +3,6 @@ package usecases
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"time"
 
 	"fr.simplified/azuredevops/api/v0beta0"
@@ -17,9 +16,7 @@ import (
 )
 
 const (
-	minReplicas     = 0  // Minimum number of replicas
-	maxReplicas     = 10 // Maximum number of replicas
-	jobsPerReplica  = 5  // Number of jobs per replica
+	jobsPerReplica  = 5 // Number of jobs per replica
 	requeueInterval = time.Second * 30
 )
 
@@ -82,28 +79,29 @@ func (r *Reconcile) Handle(ctx context.Context, azdo *v0beta0.AzureDevOps) (ctrl
 // determineDesiredReplicas calculates the number of replicas based on queue length
 func determineDesiredReplicas(queueLength int, logger logr.Logger, azdo *v0beta0.AzureDevOps) int32 {
 	// Determine min and max replicas from spec or use defaults
-	minReplicas := int32(minReplicas) // default from const
-	maxReplicas := int32(maxReplicas) // default from const
+	minReplicas := int32(1)  // default value in API type
+	maxReplicas := int32(10) // default value in API type
 
 	// Parse spec values if defined
-	if azdo.Spec.MinReplicas != "" {
-		if val, err := strconv.ParseInt(azdo.Spec.MinReplicas, 10, 32); err == nil {
-			minReplicas = int32(val)
-			logger.V(1).Info("Using spec minReplicas", "value", minReplicas)
-		} else {
-			logger.Error(err, "Invalid minReplicas in spec, using default", "default", minReplicas)
-		}
+	if azdo.Spec.MinReplicas > 0 {
+		minReplicas = azdo.Spec.MinReplicas
+		logger.V(1).Info("Using spec minReplicas", "value", minReplicas)
+	} else {
+		logger.V(1).Info("Using default minReplicas", "default", minReplicas)
 	}
 
-	if azdo.Spec.MaxReplicas != "" {
-		if val, err := strconv.ParseInt(azdo.Spec.MaxReplicas, 10, 32); err == nil {
-			maxReplicas = int32(val)
-			logger.V(1).Info("Using spec maxReplicas", "value", maxReplicas)
-		} else {
-			logger.Error(err, "Invalid maxReplicas in spec, using default", "default", maxReplicas)
-		}
+	if azdo.Spec.MaxReplicas > 0 {
+		maxReplicas = azdo.Spec.MaxReplicas
+		logger.V(1).Info("Using spec maxReplicas", "value", maxReplicas)
+	} else {
+		logger.V(1).Info("Using default maxReplicas", "default", maxReplicas)
 	}
 
+	if minReplicas > maxReplicas {
+		logger.Error(nil, "MinReplicas greater than MaxReplicas, swapping values",
+			"minReplicas", minReplicas, "maxReplicas", maxReplicas)
+		minReplicas, maxReplicas = maxReplicas, minReplicas
+	}
 	// If there are no jobs in queue, scale to minimum
 	if queueLength == 0 {
 		logger.V(1).Info("No jobs in queue, scaling to minimum", "min", minReplicas)

--- a/internal/app/usecase/reconcile.go
+++ b/internal/app/usecase/reconcile.go
@@ -3,6 +3,7 @@ package usecases
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"fr.simplified/azuredevops/api/v0beta0"
@@ -53,7 +54,7 @@ func (r *Reconcile) Handle(ctx context.Context, azdo *v0beta0.AzureDevOps) (ctrl
 
 	// Calculate desired replicas
 	currentReplicas := azdo.Status.DesiredAgents
-	desiredReplicas := determineDesiredReplicas(queueLength, logger)
+	desiredReplicas := determineDesiredReplicas(queueLength, logger, azdo)
 
 	// Update status
 	azdo.Status.QueuedJobs = int32(queueLength)
@@ -79,15 +80,43 @@ func (r *Reconcile) Handle(ctx context.Context, azdo *v0beta0.AzureDevOps) (ctrl
 }
 
 // determineDesiredReplicas calculates the number of replicas based on queue length
-func determineDesiredReplicas(queueLength int, logger logr.Logger) int32 {
-	// If there are no jobs in queue, consider scaling to minimum
+func determineDesiredReplicas(queueLength int, logger logr.Logger, azdo *v0beta0.AzureDevOps) int32 {
+	// Determine min and max replicas from spec or use defaults
+	minReplicas := int32(minReplicas) // default from const
+	maxReplicas := int32(maxReplicas) // default from const
+
+	// Parse spec values if defined
+	if azdo.Spec.MinReplicas != "" {
+		if val, err := strconv.ParseInt(azdo.Spec.MinReplicas, 10, 32); err == nil {
+			minReplicas = int32(val)
+			logger.V(1).Info("Using spec minReplicas", "value", minReplicas)
+		} else {
+			logger.Error(err, "Invalid minReplicas in spec, using default", "default", minReplicas)
+		}
+	}
+
+	if azdo.Spec.MaxReplicas != "" {
+		if val, err := strconv.ParseInt(azdo.Spec.MaxReplicas, 10, 32); err == nil {
+			maxReplicas = int32(val)
+			logger.V(1).Info("Using spec maxReplicas", "value", maxReplicas)
+		} else {
+			logger.Error(err, "Invalid maxReplicas in spec, using default", "default", maxReplicas)
+		}
+	}
+
+	// If there are no jobs in queue, scale to minimum
 	if queueLength == 0 {
-		logger.V(1).Info("No jobs in queue, scaling to minimum")
+		logger.V(1).Info("No jobs in queue, scaling to minimum", "min", minReplicas)
 		return minReplicas
 	}
 
 	// Calculate desired replicas with bounds
-	desired := (queueLength + jobsPerReplica - 1) / jobsPerReplica // Ceiling division
+	desired := int32((queueLength + jobsPerReplica - 1) / jobsPerReplica) // Ceiling division
+
+	// Ensure desired is within bounds
+	if desired < minReplicas {
+		desired = minReplicas
+	}
 	if desired > maxReplicas {
 		desired = maxReplicas
 		logger.Info("Queue length exceeds capacity",
@@ -95,7 +124,7 @@ func determineDesiredReplicas(queueLength int, logger logr.Logger) int32 {
 			"maxReplicas", maxReplicas)
 	}
 
-	return int32(desired)
+	return desired
 }
 
 // calculateRequeueInterval determines the next reconciliation interval

--- a/internal/infra/azuredevops/queue.go
+++ b/internal/infra/azuredevops/queue.go
@@ -8,15 +8,22 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
+	"golang.org/x/time/rate"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
-	AzdoFinalizerName = "fr.simplified/azdo-finalizer"
-	apiVersion        = "7.1"
+	AzdoFinalizerName     = "fr.simplified/azdo-finalizer"
+	apiVersion            = "7.1"
+	defaultRateLimit      = 5
+	defaultMaxRetries     = 3
+	defaultRetryBaseDelay = 1 * time.Second
+	cacheExpiration       = 5 * time.Minute
 )
 
 type Client interface {
@@ -32,22 +39,113 @@ type Client interface {
 }
 
 type AzureDevOpsClient struct {
-	PATToken string
-	OrgURL   string
-	Project  string
+	PATToken    string
+	OrgURL      string
+	Project     string
+	limiter     *rate.Limiter
+	poolIDCache map[string]poolCacheEntry
+	cacheMutex  sync.RWMutex
+}
+
+type poolCacheEntry struct {
+	ID        int
+	expiresAt time.Time
 }
 
 func NewAzureDevOpsClient(patToken, orgURL, project string) *AzureDevOpsClient {
 	return &AzureDevOpsClient{
-		PATToken: strings.TrimSpace(patToken),
-		OrgURL:   strings.TrimRight(orgURL, "/"),
-		Project:  project,
+		PATToken:    strings.TrimSpace(patToken),
+		OrgURL:      strings.TrimRight(orgURL, "/"),
+		Project:     project,
+		limiter:     rate.NewLimiter(rate.Limit(defaultRateLimit), 1),
+		poolIDCache: make(map[string]poolCacheEntry),
 	}
 }
 
 type QueueNameResponse struct {
 	Count int         `json:"count"`
 	Value []AgentPool `json:"value"`
+}
+
+func (a *AzureDevOpsClient) doRequestWithBackoff(ctx context.Context, req *http.Request) (*http.Response, error) {
+	logger := log.FromContext(ctx)
+	var resp *http.Response
+	var err error
+
+	// Wait for rate limiter
+	if err := a.limiter.Wait(ctx); err != nil {
+		return nil, fmt.Errorf("rate limiter wait: %w", err)
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	for attempt := 0; attempt < defaultMaxRetries; attempt++ {
+		resp, err = client.Do(req)
+
+		if err != nil {
+			if ctx.Err() == context.Canceled {
+				return nil, fmt.Errorf("request canceled: %w", err)
+			}
+
+			// Calculate backoff with jitter
+			backoff := defaultRetryBaseDelay * time.Duration(1<<attempt)
+			jitter := time.Duration(rand.Int63n(int64(backoff / 2)))
+			sleepTime := backoff + jitter
+
+			select {
+			case <-time.After(sleepTime):
+				continue
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+
+		// Check for rate limiting response
+		if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
+			// Get retry-after if available
+			retryAfter := resp.Header.Get("Retry-After")
+			var sleepTime time.Duration
+
+			if retryAfter != "" {
+				retrySeconds, err := strconv.Atoi(retryAfter)
+				if err == nil {
+					sleepTime = time.Duration(retrySeconds) * time.Second
+				}
+			}
+
+			if sleepTime == 0 {
+				// Default backoff with jitter
+				backoff := defaultRetryBaseDelay * time.Duration(1<<attempt)
+				jitter := time.Duration(rand.Int63n(int64(backoff / 2)))
+				sleepTime = backoff + jitter
+			}
+
+			// Close the response before waiting
+			if resp.Body != nil {
+				defer func() {
+					if err := resp.Body.Close(); err != nil {
+						logger.Error(err, "Failed to close response body")
+					}
+				}()
+			}
+
+			select {
+			case <-time.After(sleepTime):
+				// Retry the request with a fresh client
+				req = req.Clone(ctx)
+				continue
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+
+		// If we got here with a valid response, return it
+		if resp != nil {
+			return resp, nil
+		}
+	}
+
+	return resp, err
 }
 
 type AgentPool struct {
@@ -205,36 +303,28 @@ func GetQueueIdFromName(ctx context.Context, orgURL, project, patToken, poolName
 func (a *AzureDevOpsClient) GetQueueLength(ctx context.Context, poolName string) (int, error) {
 	logger := log.FromContext(ctx)
 
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
-	poolID, err := GetQueueIdFromName(ctxWithTimeout, a.OrgURL, a.Project, a.PATToken, poolName)
+	poolID, err := a.GetPoolIDByName(ctx, poolName)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get pool ID: %w", err)
 	}
-	logger.V(1).Info("Retrieved Pool ID", "poolID", poolID)
 
-	url := fmt.Sprintf("%s/_apis/distributedtask/pools/%s/jobrequests?api-version=7.1",
-		a.OrgURL, poolID)
+	url := fmt.Sprintf("%s/_apis/distributedtask/pools/%d/jobrequests?api-version=%s",
+		a.OrgURL, poolID, apiVersion)
 
-	req, err := http.NewRequestWithContext(ctxWithTimeout, "GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return 0, fmt.Errorf("failed to create request: %w", err)
 	}
 
 	req.Header.Set("Authorization", buildAuthHeader(a.PATToken))
 
-	client := &http.Client{
-		Timeout: 10 * time.Second,
-	}
-
-	resp, err := client.Do(req)
+	resp, err := a.doRequestWithBackoff(ctx, req)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute request: %w", err)
 	}
 	defer func() {
-		if cerr := resp.Body.Close(); cerr != nil {
-			logger.Error(cerr, "Failed to close response body")
+		if err := resp.Body.Close(); err != nil {
+			logger.Error(err, "Failed to close response body")
 		}
 	}()
 
@@ -410,6 +500,15 @@ func (a *AzureDevOpsClient) GetAgentsInPool(ctx context.Context, poolID int) ([]
 
 func (a *AzureDevOpsClient) GetPoolIDByName(ctx context.Context, poolName string) (int, error) {
 	logger := log.FromContext(ctx)
+
+	// Check cache first
+	a.cacheMutex.RLock()
+	if entry, ok := a.poolIDCache[poolName]; ok && entry.expiresAt.After(time.Now()) {
+		a.cacheMutex.RUnlock()
+		return entry.ID, nil
+	}
+	a.cacheMutex.RUnlock()
+
 	url := fmt.Sprintf("%s/_apis/distributedtask/pools?poolName=%s&api-version=%s",
 		a.OrgURL, poolName, apiVersion)
 
@@ -420,8 +519,7 @@ func (a *AzureDevOpsClient) GetPoolIDByName(ctx context.Context, poolName string
 
 	req.Header.Set("Authorization", buildAuthHeader(a.PATToken))
 
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := a.doRequestWithBackoff(ctx, req)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute request: %w", err)
 	}
@@ -432,7 +530,6 @@ func (a *AzureDevOpsClient) GetPoolIDByName(ctx context.Context, poolName string
 	}()
 
 	body, err := io.ReadAll(resp.Body)
-
 	if err != nil {
 		return 0, fmt.Errorf("failed to read response body: %w", err)
 	}
@@ -450,6 +547,16 @@ func (a *AzureDevOpsClient) GetPoolIDByName(ctx context.Context, poolName string
 		return 0, fmt.Errorf("no pool found with name: %s", poolName)
 	}
 
-	logger.V(1).Info("Retrieved pool ID", "poolName", poolName, "poolID", queueResp.Value[0].ID)
-	return queueResp.Value[0].ID, nil
+	poolID := queueResp.Value[0].ID
+
+	// Cache the result
+	a.cacheMutex.Lock()
+	a.poolIDCache[poolName] = poolCacheEntry{
+		ID:        poolID,
+		expiresAt: time.Now().Add(cacheExpiration),
+	}
+	a.cacheMutex.Unlock()
+
+	logger.V(1).Info("Retrieved pool ID", "poolName", poolName, "poolID", poolID)
+	return poolID, nil
 }

--- a/internal/infra/azuredevops/queue.go
+++ b/internal/infra/azuredevops/queue.go
@@ -281,7 +281,9 @@ func (a *AzureDevOpsClient) DeleteAgent(ctx context.Context, poolID int, agentID
 	if err != nil {
 		return fmt.Errorf("failed to execute request: %w", err)
 	}
-	defer resp.Body.Close()
+	if errClose := resp.Body.Close(); errClose != nil {
+		logger.Error(errClose, "Failed to close response body")
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -316,7 +318,9 @@ func (a *AzureDevOpsClient) DisableAgent(ctx context.Context, poolID int, agentI
 	if err != nil {
 		return fmt.Errorf("failed to execute request: %w", err)
 	}
-	defer resp.Body.Close()
+	if errClose := resp.Body.Close(); errClose != nil {
+		logger.Error(errClose, "Failed to close response body")
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -344,7 +348,9 @@ func (a *AzureDevOpsClient) GetAgentsInPool(ctx context.Context, poolID int) ([]
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute request: %w", err)
 	}
-	defer resp.Body.Close()
+	if errClose := resp.Body.Close(); errClose != nil {
+		logger.Error(errClose, "Failed to close response body")
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -381,7 +387,9 @@ func (a *AzureDevOpsClient) GetPoolIDByName(ctx context.Context, poolName string
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute request: %w", err)
 	}
-	defer resp.Body.Close()
+	if errClose := resp.Body.Close(); errClose != nil {
+		logger.Error(errClose, "Failed to close response body")
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)

--- a/internal/infra/azuredevops/queue.go
+++ b/internal/infra/azuredevops/queue.go
@@ -20,9 +20,13 @@ const (
 
 type Client interface {
 	GetQueueLength(ctx context.Context, poolName string) (int, error)
+	// GetPoolIDByName retrieves the pool ID based on the provided pool name.
 	GetPoolIDByName(ctx context.Context, poolName string) (int, error)
+	// GetAgentsInPool fetches a list of agents associated with a specified pool ID.
 	GetAgentsInPool(ctx context.Context, poolID int) ([]Agent, error)
+	// DisableAgent disables an agent identified by the given pool ID and agent ID.
 	DisableAgent(ctx context.Context, poolID int, agentID int) error
+	// DeleteAgent deletes an agent specified by the pool ID and agent ID.
 	DeleteAgent(ctx context.Context, poolID int, agentID int) error
 }
 
@@ -272,10 +276,13 @@ func (a *AzureDevOpsClient) GetQueueLength(ctx context.Context, poolName string)
 func (a *AzureDevOpsClient) DeleteAgent(ctx context.Context, poolID int, agentID int) error {
 	logger := log.FromContext(ctx)
 
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
 	url := fmt.Sprintf("%s/_apis/distributedtask/pools/%d/agents/%d?api-version=%s",
 		a.OrgURL, poolID, agentID, apiVersion)
 
-	req, err := http.NewRequestWithContext(ctx, "DELETE", url, nil)
+	req, err := http.NewRequestWithContext(ctxWithTimeout, "DELETE", url, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}

--- a/internal/infra/azuredevops/queue.go
+++ b/internal/infra/azuredevops/queue.go
@@ -122,11 +122,9 @@ func (a *AzureDevOpsClient) doRequestWithBackoff(ctx context.Context, req *http.
 
 			// Close the response before waiting
 			if resp.Body != nil {
-				defer func() {
-					if err := resp.Body.Close(); err != nil {
-						logger.Error(err, "Failed to close response body")
-					}
-				}()
+				if err := resp.Body.Close(); err != nil {
+					logger.Error(err, "Failed to close response body")
+				}
 			}
 
 			select {
@@ -322,11 +320,9 @@ func (a *AzureDevOpsClient) GetQueueLength(ctx context.Context, poolName string)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute request: %w", err)
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			logger.Error(err, "Failed to close response body")
-		}
-	}()
+	if errClose := resp.Body.Close(); errClose != nil {
+		logger.Error(errClose, "Failed to close response body")
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -444,11 +440,9 @@ func (a *AzureDevOpsClient) DisableAgent(ctx context.Context, poolID int, agentI
 	if err != nil {
 		return fmt.Errorf("failed to execute request: %w", err)
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			logger.Error(err, "Failed to close response body")
-		}
-	}()
+	if errClose := resp.Body.Close(); errClose != nil {
+		logger.Error(errClose, "Failed to close response body")
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -475,11 +469,9 @@ func (a *AzureDevOpsClient) GetAgentsInPool(ctx context.Context, poolID int) ([]
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute request: %w", err)
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			logger.Error(err, "Failed to close response body")
-		}
-	}()
+	if errClose := resp.Body.Close(); errClose != nil {
+		logger.Error(errClose, "Failed to close response body")
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -523,11 +515,9 @@ func (a *AzureDevOpsClient) GetPoolIDByName(ctx context.Context, poolName string
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute request: %w", err)
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			logger.Error(err, "Failed to close response body")
-		}
-	}()
+	if errClose := resp.Body.Close(); errClose != nil {
+		logger.Error(errClose, "Failed to close response body")
+	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/infra/azuredevops/queue.go
+++ b/internal/infra/azuredevops/queue.go
@@ -274,46 +274,45 @@ func (a *AzureDevOpsClient) GetQueueLength(ctx context.Context, poolName string)
 }
 
 func (a *AzureDevOpsClient) DeleteAgent(ctx context.Context, poolID int, agentID int) error {
-	logger := log.FromContext(ctx)
 
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
+	for attempt := 0; attempt < 3; attempt++ {
+		url := fmt.Sprintf("%s/_apis/distributedtask/pools/%d/agents/%d?api-version=%s",
+			a.OrgURL, poolID, agentID, apiVersion)
 
-	url := fmt.Sprintf("%s/_apis/distributedtask/pools/%d/agents/%d?api-version=%s",
-		a.OrgURL, poolID, agentID, apiVersion)
-
-	req, err := http.NewRequestWithContext(ctxWithTimeout, "DELETE", url, nil)
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Authorization", buildAuthHeader(a.PATToken))
-
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to execute request: %w", err)
-	}
-	defer func() {
-		if cerr := resp.Body.Close(); cerr != nil {
-			logger.Error(cerr, "Failed to close response body")
+		req, err := http.NewRequestWithContext(ctx, "DELETE", url, nil)
+		if err != nil {
+			return fmt.Errorf("failed to create request: %w", err)
 		}
-	}()
 
-	// Accept both 200 OK and 204 No Content as success
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		req.Header.Set("Authorization", buildAuthHeader(a.PATToken))
+
+		client := &http.Client{Timeout: 10 * time.Second}
+		resp, err := client.Do(req)
+		if err != nil {
+			return fmt.Errorf("failed to execute request: %w", err)
+		}
+
 		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNoContent {
+			return nil
+		}
+
+		if resp.StatusCode == http.StatusBadRequest && strings.Contains(string(body), "TaskAgentJobStillRunningException") {
+			if attempt < 2 {
+				time.Sleep(time.Duration(attempt+1) * 5 * time.Second)
+				continue
+			}
+		}
+
 		return fmt.Errorf("unexpected status code: %d - %s", resp.StatusCode, string(body))
 	}
 
-	logger.Info("Successfully deleted agent", "poolID", poolID, "agentID", agentID)
-	return nil
+	return fmt.Errorf("failed to delete agent after retries")
 }
 
 func (a *AzureDevOpsClient) DisableAgent(ctx context.Context, poolID int, agentID int) error {
-	logger := log.FromContext(ctx)
-
-	// Add validation
 	if agentID <= 0 {
 		return fmt.Errorf("invalid agent ID: %d", agentID)
 	}
@@ -321,28 +320,15 @@ func (a *AzureDevOpsClient) DisableAgent(ctx context.Context, poolID int, agentI
 		return fmt.Errorf("invalid pool ID: %d", poolID)
 	}
 
-	// Log input parameters
-	logger.V(1).Info("DisableAgent called with",
-		"poolID", poolID,
-		"agentID", agentID,
-		"orgURL", a.OrgURL)
-
-	// Extract organization name from URL
 	orgName := strings.TrimPrefix(strings.TrimPrefix(a.OrgURL, "https://"), "dev.azure.com/")
-
-	// Construct URL ensuring no double slashes
 	url := fmt.Sprintf("https://dev.azure.com/%s/_apis/distributedtask/pools/%d/agents/%d?api-version=%s",
 		orgName, poolID, agentID, apiVersion)
 
-	// Log the constructed URL
-	logger.V(1).Info("Making request to", "url", url)
-
-	// Create the request body
 	payload := struct {
 		ID      int  `json:"id"`
 		Enabled bool `json:"enabled"`
 	}{
-		ID:      agentID, // Include the agent ID in the payload
+		ID:      agentID,
 		Enabled: false,
 	}
 
@@ -350,9 +336,6 @@ func (a *AzureDevOpsClient) DisableAgent(ctx context.Context, poolID int, agentI
 	if err != nil {
 		return fmt.Errorf("failed to marshal request body: %w", err)
 	}
-
-	// Log the request payload
-	logger.V(1).Info("Request payload", "body", string(jsonData))
 
 	req, err := http.NewRequestWithContext(ctx, "PATCH", url, strings.NewReader(string(jsonData)))
 	if err != nil {
@@ -367,31 +350,17 @@ func (a *AzureDevOpsClient) DisableAgent(ctx context.Context, poolID int, agentI
 	if err != nil {
 		return fmt.Errorf("failed to execute request: %w", err)
 	}
-	defer func() {
-		if cerr := resp.Body.Close(); cerr != nil {
-			logger.Error(cerr, "Failed to close response body")
-		}
-	}()
-
-	// Read the response body
-	body, _ := io.ReadAll(resp.Body)
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		logger.Error(fmt.Errorf("request failed"), "Request details",
-			"statusCode", resp.StatusCode,
-			"body", string(body),
-			"url", url,
-			"poolID", poolID,
-			"agentID", agentID)
+		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("unexpected status code: %d - %s", resp.StatusCode, string(body))
 	}
 
-	logger.Info("Successfully disabled agent", "poolID", poolID, "agentID", agentID)
 	return nil
 }
 
 func (a *AzureDevOpsClient) GetAgentsInPool(ctx context.Context, poolID int) ([]Agent, error) {
-	logger := log.FromContext(ctx)
 	url := fmt.Sprintf("%s/_apis/distributedtask/pools/%d/agents?api-version=%s",
 		a.OrgURL, poolID, apiVersion)
 
@@ -407,12 +376,7 @@ func (a *AzureDevOpsClient) GetAgentsInPool(ctx context.Context, poolID int) ([]
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute request: %w", err)
 	}
-	// Defer closing the response body
-	defer func() {
-		if cerr := resp.Body.Close(); cerr != nil {
-			logger.Error(cerr, "Failed to close response body")
-		}
-	}()
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -428,7 +392,6 @@ func (a *AzureDevOpsClient) GetAgentsInPool(ctx context.Context, poolID int) ([]
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	logger.V(1).Info("Retrieved agents", "poolID", poolID, "count", agentResp.Count)
 	return agentResp.Value, nil
 }
 

--- a/internal/infra/azuredevops/queue.go
+++ b/internal/infra/azuredevops/queue.go
@@ -362,44 +362,35 @@ func (a *AzureDevOpsClient) GetQueueLength(ctx context.Context, poolName string)
 
 func (a *AzureDevOpsClient) DeleteAgent(ctx context.Context, poolID int, agentID int) error {
 	logger := log.FromContext(ctx)
-	for attempt := 0; attempt < 3; attempt++ {
-		url := fmt.Sprintf("%s/_apis/distributedtask/pools/%d/agents/%d?api-version=%s",
-			a.OrgURL, poolID, agentID, apiVersion)
+	url := fmt.Sprintf("%s/_apis/distributedtask/pools/%d/agents/%d?api-version=%s",
+		a.OrgURL, poolID, agentID, apiVersion)
 
-		req, err := http.NewRequestWithContext(ctx, "DELETE", url, nil)
-		if err != nil {
-			return fmt.Errorf("failed to create request: %w", err)
-		}
-
-		req.Header.Set("Authorization", buildAuthHeader(a.PATToken))
-
-		client := &http.Client{Timeout: 10 * time.Second}
-		resp, err := client.Do(req)
-		if err != nil {
-			return fmt.Errorf("failed to execute request: %w", err)
-		}
-
-		body, _ := io.ReadAll(resp.Body)
-		if err := resp.Body.Close(); err != nil {
-			logger.Error(err, "Failed to close response body")
-		}
-
-		if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNoContent {
-			return nil
-		}
-
-		if resp.StatusCode == http.StatusBadRequest && strings.Contains(string(body), "TaskAgentJobStillRunningException") {
-			if attempt < 2 {
-				jitter := time.Duration(rand.Int63n(1000)) * time.Millisecond
-				time.Sleep(time.Duration(attempt+1)*5*time.Second + jitter)
-				continue
-			}
-		}
-
-		return fmt.Errorf("unexpected status code: %d - %s", resp.StatusCode, string(body))
+	req, err := http.NewRequestWithContext(ctx, "DELETE", url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
 	}
 
-	return fmt.Errorf("failed to delete agent after retries")
+	req.Header.Set("Authorization", buildAuthHeader(a.PATToken))
+
+	resp, err := a.doRequestWithBackoff(ctx, req)
+	if err != nil {
+		return fmt.Errorf("failed to execute request: %w", err)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if err := resp.Body.Close(); err != nil {
+		logger.Error(err, "Failed to close response body")
+	}
+
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
+
+	if resp.StatusCode == http.StatusBadRequest && strings.Contains(string(body), "TaskAgentJobStillRunningException") {
+		return fmt.Errorf("failed to delete agent as it is still running jobs")
+	}
+
+	return fmt.Errorf("unexpected status code: %d - %s", resp.StatusCode, string(body))
 }
 
 func (a *AzureDevOpsClient) DisableAgent(ctx context.Context, poolID int, agentID int) error {

--- a/internal/infra/azuredevops/queue.go
+++ b/internal/infra/azuredevops/queue.go
@@ -317,6 +317,7 @@ func (a *AzureDevOpsClient) DeleteAgent(ctx context.Context, poolID int, agentID
 }
 
 func (a *AzureDevOpsClient) DisableAgent(ctx context.Context, poolID int, agentID int) error {
+	logger := log.FromContext(ctx)
 	if agentID <= 0 {
 		return fmt.Errorf("invalid agent ID: %d", agentID)
 	}
@@ -353,7 +354,11 @@ func (a *AzureDevOpsClient) DisableAgent(ctx context.Context, poolID int, agentI
 	if err != nil {
 		return fmt.Errorf("failed to execute request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logger.Error(err, "Failed to close response body")
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -364,6 +369,7 @@ func (a *AzureDevOpsClient) DisableAgent(ctx context.Context, poolID int, agentI
 }
 
 func (a *AzureDevOpsClient) GetAgentsInPool(ctx context.Context, poolID int) ([]Agent, error) {
+	logger := log.FromContext(ctx)
 	url := fmt.Sprintf("%s/_apis/distributedtask/pools/%d/agents?api-version=%s",
 		a.OrgURL, poolID, apiVersion)
 
@@ -379,7 +385,11 @@ func (a *AzureDevOpsClient) GetAgentsInPool(ctx context.Context, poolID int) ([]
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logger.Error(err, "Failed to close response body")
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)

--- a/internal/infra/azuredevops/queue.go
+++ b/internal/infra/azuredevops/queue.go
@@ -13,6 +13,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+const (
+	AzdoFinalizerName = "fr.simplified/azdo-finalizer"
+	apiVersion        = "7.1"
+)
+
 type Client interface {
 	GetQueueLength(ctx context.Context, poolName string) (int, error)
 	GetPoolIDByName(ctx context.Context, poolName string) (int, error)
@@ -266,8 +271,9 @@ func (a *AzureDevOpsClient) GetQueueLength(ctx context.Context, poolName string)
 
 func (a *AzureDevOpsClient) DeleteAgent(ctx context.Context, poolID int, agentID int) error {
 	logger := log.FromContext(ctx)
+
 	url := fmt.Sprintf("%s/_apis/distributedtask/pools/%d/agents/%d?api-version=%s",
-		a.OrgURL, poolID, agentID, ApiVersion)
+		a.OrgURL, poolID, agentID, apiVersion)
 
 	req, err := http.NewRequestWithContext(ctx, "DELETE", url, nil)
 	if err != nil {
@@ -281,11 +287,14 @@ func (a *AzureDevOpsClient) DeleteAgent(ctx context.Context, poolID int, agentID
 	if err != nil {
 		return fmt.Errorf("failed to execute request: %w", err)
 	}
-	if errClose := resp.Body.Close(); errClose != nil {
-		logger.Error(errClose, "Failed to close response body")
-	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			logger.Error(cerr, "Failed to close response body")
+		}
+	}()
 
-	if resp.StatusCode != http.StatusOK {
+	// Accept both 200 OK and 204 No Content as success
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("unexpected status code: %d - %s", resp.StatusCode, string(body))
 	}
@@ -296,14 +305,47 @@ func (a *AzureDevOpsClient) DeleteAgent(ctx context.Context, poolID int, agentID
 
 func (a *AzureDevOpsClient) DisableAgent(ctx context.Context, poolID int, agentID int) error {
 	logger := log.FromContext(ctx)
-	url := fmt.Sprintf("%s/_apis/distributedtask/pools/%d/agents/%d?api-version=%s",
-		a.OrgURL, poolID, agentID, ApiVersion)
 
-	payload := map[string]bool{"enabled": false}
+	// Add validation
+	if agentID <= 0 {
+		return fmt.Errorf("invalid agent ID: %d", agentID)
+	}
+	if poolID <= 0 {
+		return fmt.Errorf("invalid pool ID: %d", poolID)
+	}
+
+	// Log input parameters
+	logger.V(1).Info("DisableAgent called with",
+		"poolID", poolID,
+		"agentID", agentID,
+		"orgURL", a.OrgURL)
+
+	// Extract organization name from URL
+	orgName := strings.TrimPrefix(strings.TrimPrefix(a.OrgURL, "https://"), "dev.azure.com/")
+
+	// Construct URL ensuring no double slashes
+	url := fmt.Sprintf("https://dev.azure.com/%s/_apis/distributedtask/pools/%d/agents/%d?api-version=%s",
+		orgName, poolID, agentID, apiVersion)
+
+	// Log the constructed URL
+	logger.V(1).Info("Making request to", "url", url)
+
+	// Create the request body
+	payload := struct {
+		ID      int  `json:"id"`
+		Enabled bool `json:"enabled"`
+	}{
+		ID:      agentID, // Include the agent ID in the payload
+		Enabled: false,
+	}
+
 	jsonData, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("failed to marshal request body: %w", err)
 	}
+
+	// Log the request payload
+	logger.V(1).Info("Request payload", "body", string(jsonData))
 
 	req, err := http.NewRequestWithContext(ctx, "PATCH", url, strings.NewReader(string(jsonData)))
 	if err != nil {
@@ -318,12 +360,22 @@ func (a *AzureDevOpsClient) DisableAgent(ctx context.Context, poolID int, agentI
 	if err != nil {
 		return fmt.Errorf("failed to execute request: %w", err)
 	}
-	if errClose := resp.Body.Close(); errClose != nil {
-		logger.Error(errClose, "Failed to close response body")
-	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			logger.Error(cerr, "Failed to close response body")
+		}
+	}()
+
+	// Read the response body
+	body, _ := io.ReadAll(resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		logger.Error(fmt.Errorf("request failed"), "Request details",
+			"statusCode", resp.StatusCode,
+			"body", string(body),
+			"url", url,
+			"poolID", poolID,
+			"agentID", agentID)
 		return fmt.Errorf("unexpected status code: %d - %s", resp.StatusCode, string(body))
 	}
 
@@ -334,7 +386,7 @@ func (a *AzureDevOpsClient) DisableAgent(ctx context.Context, poolID int, agentI
 func (a *AzureDevOpsClient) GetAgentsInPool(ctx context.Context, poolID int) ([]Agent, error) {
 	logger := log.FromContext(ctx)
 	url := fmt.Sprintf("%s/_apis/distributedtask/pools/%d/agents?api-version=%s",
-		a.OrgURL, poolID, ApiVersion)
+		a.OrgURL, poolID, apiVersion)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
@@ -348,9 +400,12 @@ func (a *AzureDevOpsClient) GetAgentsInPool(ctx context.Context, poolID int) ([]
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute request: %w", err)
 	}
-	if errClose := resp.Body.Close(); errClose != nil {
-		logger.Error(errClose, "Failed to close response body")
-	}
+	// Defer closing the response body
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			logger.Error(cerr, "Failed to close response body")
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -373,7 +428,7 @@ func (a *AzureDevOpsClient) GetAgentsInPool(ctx context.Context, poolID int) ([]
 func (a *AzureDevOpsClient) GetPoolIDByName(ctx context.Context, poolName string) (int, error) {
 	logger := log.FromContext(ctx)
 	url := fmt.Sprintf("%s/_apis/distributedtask/pools?poolName=%s&api-version=%s",
-		a.OrgURL, poolName, ApiVersion)
+		a.OrgURL, poolName, apiVersion)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
@@ -387,17 +442,20 @@ func (a *AzureDevOpsClient) GetPoolIDByName(ctx context.Context, poolName string
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute request: %w", err)
 	}
-	if errClose := resp.Body.Close(); errClose != nil {
-		logger.Error(errClose, "Failed to close response body")
+	// Important: read the body before closing
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close() // Always close the body
+
+	if err != nil {
+		return 0, fmt.Errorf("failed to read response body: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
 		return 0, fmt.Errorf("unexpected status code: %d - %s", resp.StatusCode, string(body))
 	}
 
 	var queueResp QueueNameResponse
-	if err := json.NewDecoder(resp.Body).Decode(&queueResp); err != nil {
+	if err := json.Unmarshal(body, &queueResp); err != nil {
 		return 0, fmt.Errorf("failed to parse response: %w", err)
 	}
 

--- a/internal/infra/azuredevops/queue.go
+++ b/internal/infra/azuredevops/queue.go
@@ -15,6 +15,10 @@ import (
 
 type Client interface {
 	GetQueueLength(ctx context.Context, poolName string) (int, error)
+	GetPoolIDByName(ctx context.Context, poolName string) (int, error)
+	GetAgentsInPool(ctx context.Context, poolID int) ([]Agent, error)
+	DisableAgent(ctx context.Context, poolID int, agentID int) error
+	DeleteAgent(ctx context.Context, poolID int, agentID int) error
 }
 
 type AzureDevOpsClient struct {
@@ -258,4 +262,141 @@ func (a *AzureDevOpsClient) GetQueueLength(ctx context.Context, poolName string)
 		"pendingJobs", pendingJobs)
 
 	return pendingJobs, nil
+}
+
+func (a *AzureDevOpsClient) DeleteAgent(ctx context.Context, poolID int, agentID int) error {
+	logger := log.FromContext(ctx)
+	url := fmt.Sprintf("%s/_apis/distributedtask/pools/%d/agents/%d?api-version=%s",
+		a.OrgURL, poolID, agentID, ApiVersion)
+
+	req, err := http.NewRequestWithContext(ctx, "DELETE", url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", buildAuthHeader(a.PATToken))
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected status code: %d - %s", resp.StatusCode, string(body))
+	}
+
+	logger.Info("Successfully deleted agent", "poolID", poolID, "agentID", agentID)
+	return nil
+}
+
+func (a *AzureDevOpsClient) DisableAgent(ctx context.Context, poolID int, agentID int) error {
+	logger := log.FromContext(ctx)
+	url := fmt.Sprintf("%s/_apis/distributedtask/pools/%d/agents/%d?api-version=%s",
+		a.OrgURL, poolID, agentID, ApiVersion)
+
+	payload := map[string]bool{"enabled": false}
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request body: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "PATCH", url, strings.NewReader(string(jsonData)))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", buildAuthHeader(a.PATToken))
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected status code: %d - %s", resp.StatusCode, string(body))
+	}
+
+	logger.Info("Successfully disabled agent", "poolID", poolID, "agentID", agentID)
+	return nil
+}
+
+func (a *AzureDevOpsClient) GetAgentsInPool(ctx context.Context, poolID int) ([]Agent, error) {
+	logger := log.FromContext(ctx)
+	url := fmt.Sprintf("%s/_apis/distributedtask/pools/%d/agents?api-version=%s",
+		a.OrgURL, poolID, ApiVersion)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", buildAuthHeader(a.PATToken))
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("unexpected status code: %d - %s", resp.StatusCode, string(body))
+	}
+
+	var agentResp struct {
+		Count int     `json:"count"`
+		Value []Agent `json:"value"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&agentResp); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	logger.V(1).Info("Retrieved agents", "poolID", poolID, "count", agentResp.Count)
+	return agentResp.Value, nil
+}
+
+func (a *AzureDevOpsClient) GetPoolIDByName(ctx context.Context, poolName string) (int, error) {
+	logger := log.FromContext(ctx)
+	url := fmt.Sprintf("%s/_apis/distributedtask/pools?poolName=%s&api-version=%s",
+		a.OrgURL, poolName, ApiVersion)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", buildAuthHeader(a.PATToken))
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return 0, fmt.Errorf("unexpected status code: %d - %s", resp.StatusCode, string(body))
+	}
+
+	var queueResp QueueNameResponse
+	if err := json.NewDecoder(resp.Body).Decode(&queueResp); err != nil {
+		return 0, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if queueResp.Count == 0 || len(queueResp.Value) == 0 {
+		return 0, fmt.Errorf("no pool found with name: %s", poolName)
+	}
+
+	logger.V(1).Info("Retrieved pool ID", "poolName", poolName, "poolID", queueResp.Value[0].ID)
+	return queueResp.Value[0].ID, nil
 }

--- a/internal/infra/azuredevops/queue.go
+++ b/internal/infra/azuredevops/queue.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"strings"
 	"time"
@@ -274,7 +275,7 @@ func (a *AzureDevOpsClient) GetQueueLength(ctx context.Context, poolName string)
 }
 
 func (a *AzureDevOpsClient) DeleteAgent(ctx context.Context, poolID int, agentID int) error {
-
+	logger := log.FromContext(ctx)
 	for attempt := 0; attempt < 3; attempt++ {
 		url := fmt.Sprintf("%s/_apis/distributedtask/pools/%d/agents/%d?api-version=%s",
 			a.OrgURL, poolID, agentID, apiVersion)
@@ -293,7 +294,9 @@ func (a *AzureDevOpsClient) DeleteAgent(ctx context.Context, poolID int, agentID
 		}
 
 		body, _ := io.ReadAll(resp.Body)
-		resp.Body.Close()
+		if err := resp.Body.Close(); err != nil {
+			logger.Error(err, "Failed to close response body")
+		}
 
 		if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNoContent {
 			return nil
@@ -301,7 +304,8 @@ func (a *AzureDevOpsClient) DeleteAgent(ctx context.Context, poolID int, agentID
 
 		if resp.StatusCode == http.StatusBadRequest && strings.Contains(string(body), "TaskAgentJobStillRunningException") {
 			if attempt < 2 {
-				time.Sleep(time.Duration(attempt+1) * 5 * time.Second)
+				jitter := time.Duration(rand.Int63n(1000)) * time.Millisecond
+				time.Sleep(time.Duration(attempt+1)*5*time.Second + jitter)
 				continue
 			}
 		}
@@ -320,9 +324,8 @@ func (a *AzureDevOpsClient) DisableAgent(ctx context.Context, poolID int, agentI
 		return fmt.Errorf("invalid pool ID: %d", poolID)
 	}
 
-	orgName := strings.TrimPrefix(strings.TrimPrefix(a.OrgURL, "https://"), "dev.azure.com/")
-	url := fmt.Sprintf("https://dev.azure.com/%s/_apis/distributedtask/pools/%d/agents/%d?api-version=%s",
-		orgName, poolID, agentID, apiVersion)
+	url := fmt.Sprintf("%s/_apis/distributedtask/pools/%d/agents/%d?api-version=%s",
+		a.OrgURL, poolID, agentID, apiVersion)
 
 	payload := struct {
 		ID      int  `json:"id"`
@@ -412,9 +415,13 @@ func (a *AzureDevOpsClient) GetPoolIDByName(ctx context.Context, poolName string
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute request: %w", err)
 	}
-	// Important: read the body before closing
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logger.Error(err, "Failed to close response body")
+		}
+	}()
+
 	body, err := io.ReadAll(resp.Body)
-	resp.Body.Close() // Always close the body
 
 	if err != nil {
 		return 0, fmt.Errorf("failed to read response body: %w", err)

--- a/internal/infra/azuredevops/types.go
+++ b/internal/infra/azuredevops/types.go
@@ -1,10 +1,5 @@
 package azuredevops
 
-const (
-	AzdoFinalizerName = "fr.simplified/azdo-finalizer"
-	ApiVersion        = "7.1"
-)
-
 type Agent struct {
 	ID      int    `json:"id"`
 	Name    string `json:"name"`

--- a/internal/infra/azuredevops/types.go
+++ b/internal/infra/azuredevops/types.go
@@ -1,0 +1,14 @@
+package azuredevops
+
+const (
+	AzdoFinalizerName = "fr.simplified/azdo-finalizer"
+	ApiVersion        = "7.1"
+)
+
+type Agent struct {
+	ID      int    `json:"id"`
+	Name    string `json:"name"`
+	Status  string `json:"status"`
+	Enabled bool   `json:"enabled"`
+	PoolID  int    `json:"poolId"`
+}

--- a/internal/infra/kubernetes/reconcile.go
+++ b/internal/infra/kubernetes/reconcile.go
@@ -131,6 +131,7 @@ func (k *KubernetesClient) ReconcileDeployment(ctx context.Context, cr *v0beta0.
 			podTemplateSpec.Spec.Containers[i].Command = []string{"/bin/sh", "-c"}
 			podTemplateSpec.Spec.Containers[i].Args = []string{
 				"trap 'touch /usr/share/pod/done' EXIT\n./start.sh",
+				"--once",
 			}
 			podTemplateSpec.Spec.Containers[i].VolumeMounts = append(
 				podTemplateSpec.Spec.Containers[i].VolumeMounts,

--- a/internal/infra/kubernetes/reconcile.go
+++ b/internal/infra/kubernetes/reconcile.go
@@ -92,6 +92,15 @@ func (k *KubernetesClient) ReconcileDeployment(ctx context.Context, cr *v0beta0.
 	podTemplateSpec := corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{"app": "azdo-agent"},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: cr.APIVersion,
+					Kind:       cr.Kind,
+					Name:       cr.Name,
+					UID:        cr.UID,
+					Controller: ptr.To(true),
+				},
+			},
 		},
 		Spec: corev1.PodSpec{
 			ImagePullSecrets: imagePullSecrets,

--- a/internal/interfaces/controller/azuredevops_controller.go
+++ b/internal/interfaces/controller/azuredevops_controller.go
@@ -92,7 +92,7 @@ func (r *AzureDevOpsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			logger.Error(err, "Failed to handle pod event")
 			return ctrl.Result{RequeueAfter: time.Minute}, err
 		}
-		return ctrl.Result{RequeueAfter: 3 * time.Second}, nil
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	} else if !apierrors.IsNotFound(err) {
 		// Unexpected error
 		logger.Error(err, "Failed to get resource")
@@ -104,7 +104,7 @@ func (r *AzureDevOpsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if err := r.Get(ctxWithTimeout, req.NamespacedName, &cr); err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.V(1).Info("Resource not found, ignoring")
-			return ctrl.Result{RequeueAfter: 3 * time.Second}, nil
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
 		logger.Error(err, "Failed to get resource")
 		return ctrl.Result{}, err
@@ -147,10 +147,10 @@ func (r *AzureDevOpsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			}
 
 			logger.Info("Successfully cleaned up Azure DevOps resources")
-			return ctrl.Result{RequeueAfter: 3 * time.Second}, nil
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
 		// Finalizer already removed, nothing to do
-		return ctrl.Result{RequeueAfter: 3 * time.Second}, nil
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 	// Add finalizer if it doesn't exist
 	if !controllerutil.ContainsFinalizer(&cr, azuredevops.AzdoFinalizerName) {
@@ -375,8 +375,8 @@ func (r *AzureDevOpsReconciler) deleteExternalAzDOResources(ctx context.Context,
 				if err := client.DisableAgent(ctx, poolID, agent.ID); err != nil {
 					logger.Error(err, "Failed to disable agent", "agentID", agent.ID)
 					failureError = multierr.Append(failureError, err)
-					// failed++
-					// continue
+					failed++
+					continue
 				}
 			}
 

--- a/internal/interfaces/controller/azuredevops_controller.go
+++ b/internal/interfaces/controller/azuredevops_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	usecases "fr.simplified/azuredevops/internal/app/usecase"
@@ -17,6 +18,7 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	agentsv0beta0 "fr.simplified/azuredevops/api/v0beta0"
@@ -99,6 +101,51 @@ func (r *AzureDevOpsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if crCopy.Status.Conditions == nil {
 		crCopy.Status.Conditions = []metav1.Condition{}
 	}
+	// examine DeletionTimestamp to determine if object is under deletion
+	if !cr.ObjectMeta.DeletionTimestamp.IsZero() {
+		// Resource is being deleted
+		if controllerutil.ContainsFinalizer(&cr, azuredevops.AzdoFinalizerName) {
+			logger.Info("Resource is being deleted, cleaning up Azure DevOps resources")
+
+			// Get PAT token for Azure DevOps API access
+			patToken, err := r.getPATToken(ctxWithTimeout, req, cr.Spec.PatSecretRef)
+			if err != nil {
+				logger.Error(err, "Failed to get PAT token during cleanup")
+				return ctrl.Result{RequeueAfter: time.Minute}, err
+			}
+
+			// Create Azure DevOps client
+			azureDevOpsClient := azuredevops.NewAzureDevOpsClient(patToken, cr.Spec.OrgURL, cr.Spec.Project)
+
+			// Execute cleanup of Azure DevOps resources
+			if err := r.deleteExternalAzDOResources(ctxWithTimeout, &cr, azureDevOpsClient); err != nil {
+				logger.Error(err, "Failed to clean up Azure DevOps resources")
+				return ctrl.Result{RequeueAfter: time.Minute}, err
+			}
+
+			// Remove finalizer after successful cleanup
+			controllerutil.RemoveFinalizer(&cr, azuredevops.AzdoFinalizerName)
+			if err := r.Update(ctxWithTimeout, &cr); err != nil {
+				logger.Error(err, "Failed to remove finalizer")
+				return ctrl.Result{}, err
+			}
+
+			logger.Info("Successfully cleaned up Azure DevOps resources")
+			return ctrl.Result{}, nil
+		}
+		// Finalizer already removed, nothing to do
+		return ctrl.Result{}, nil
+	}
+	// Add finalizer if it doesn't exist
+	if !controllerutil.ContainsFinalizer(&cr, azuredevops.AzdoFinalizerName) {
+		controllerutil.AddFinalizer(&cr, azuredevops.AzdoFinalizerName)
+		if err := r.Update(ctxWithTimeout, &cr); err != nil {
+			logger.Error(err, "Failed to add finalizer")
+			return ctrl.Result{}, err
+		}
+		// Return early after adding finalizer to avoid race conditions
+		return ctrl.Result{Requeue: true}, nil
+	}
 
 	// First update status to Processing
 	r.updateStatus(ctxWithTimeout, crCopy, "Processing", "Reconciling Azure DevOps agent pool")
@@ -163,6 +210,7 @@ func (r *AzureDevOpsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 		crCopy.Status.CurrentAgents = newReplicas
 		crCopy.Status.DesiredAgents = *deployment.Spec.Replicas
+		crCopy.Status.ReadyAgents = *deployment.Spec.Replicas
 
 		if currentReplicas != newReplicas {
 			crCopy.Status.LastScalingTime = &metav1.Time{Time: time.Now()}
@@ -236,6 +284,7 @@ func (r *AzureDevOpsReconciler) updateStatus(ctx context.Context, cr *agentsv0be
 		updatedCR.Status.CurrentAgents = cr.Status.CurrentAgents
 		updatedCR.Status.QueuedJobs = cr.Status.QueuedJobs
 		updatedCR.Status.DesiredAgents = cr.Status.DesiredAgents
+		updatedCR.Status.ReadyAgents = cr.Status.ReadyAgents
 
 		// Update condition
 		var status metav1.ConditionStatus
@@ -280,4 +329,58 @@ func calculateRequeueInterval(lastFailure *metav1.Time) time.Duration {
 		return maxRequeueInterval
 	}
 	return interval
+}
+
+func (r *AzureDevOpsReconciler) deleteExternalAzDOResources(ctx context.Context, cr *agentsv0beta0.AzureDevOps, client azuredevops.Client) error {
+	logger := log.FromContext(ctx).WithValues(
+		"name", cr.Name,
+		"namespace", cr.Namespace,
+	)
+
+	// Get pool ID from pool name
+	poolID, err := client.GetPoolIDByName(ctx, cr.Spec.PoolName)
+	if err != nil {
+		return fmt.Errorf("failed to get pool ID: %w", err)
+	}
+
+	// Get all agents in the pool
+	agents, err := client.GetAgentsInPool(ctx, poolID)
+	if err != nil {
+		return fmt.Errorf("failed to get agents in pool: %w", err)
+	}
+
+	// Find and disable/delete agents with names that match our pattern
+	agentPrefix := fmt.Sprintf("%s-", cr.Name)
+
+	for _, agent := range agents {
+		// Check if the agent belongs to this resource by checking name prefix
+		if strings.HasPrefix(agent.Name, agentPrefix) {
+			logger.Info("Found agent to cleanup",
+				"agentID", agent.ID,
+				"agentName", agent.Name,
+				"agentStatus", agent.Status)
+
+			// Disable agent first
+			if agent.Enabled {
+				if err := client.DisableAgent(ctx, poolID, agent.ID); err != nil {
+					logger.Error(err, "Failed to disable agent", "agentID", agent.ID)
+					// Continue with other agents even if this one fails
+					continue
+				}
+				logger.Info("Successfully disabled agent", "agentID", agent.ID)
+			}
+
+			// Delete agent
+			if err := client.DeleteAgent(ctx, poolID, agent.ID); err != nil {
+				logger.Error(err, "Failed to delete agent", "agentID", agent.ID)
+				// Continue with other agents even if this one fails
+				continue
+			}
+
+			logger.Info("Successfully deleted agent", "agentID", agent.ID)
+		}
+	}
+
+	logger.Info("Azure DevOps resource cleanup completed")
+	return nil
 }

--- a/internal/interfaces/controller/azuredevops_controller.go
+++ b/internal/interfaces/controller/azuredevops_controller.go
@@ -210,7 +210,7 @@ func (r *AzureDevOpsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 		crCopy.Status.CurrentAgents = newReplicas
 		crCopy.Status.DesiredAgents = *deployment.Spec.Replicas
-		crCopy.Status.ReadyAgents = *deployment.Spec.Replicas
+		crCopy.Status.ReadyAgents = newReplicas
 
 		if currentReplicas != newReplicas {
 			crCopy.Status.LastScalingTime = &metav1.Time{Time: time.Now()}

--- a/internal/interfaces/controller/azuredevops_controller.go
+++ b/internal/interfaces/controller/azuredevops_controller.go
@@ -374,9 +374,9 @@ func (r *AzureDevOpsReconciler) deleteExternalAzDOResources(ctx context.Context,
 			if agent.Enabled {
 				if err := client.DisableAgent(ctx, poolID, agent.ID); err != nil {
 					logger.Error(err, "Failed to disable agent", "agentID", agent.ID)
-					failed++
 					failureError = multierr.Append(failureError, err)
-					continue
+					// failed++
+					// continue
 				}
 			}
 
@@ -481,6 +481,9 @@ func (r *AzureDevOpsReconciler) handlePodEvent(ctx context.Context, pod *corev1.
 
 				logger.V(2).Info("Cleanup completed", "successfulCleanups", success, "failedCleanups", failed)
 
+				if failed > 0 {
+					return fmt.Errorf("failed to clean up %d Azure DevOps agents during pod event handling", failed)
+				}
 				return nil
 			}
 		}

--- a/internal/interfaces/controller/azuredevops_controller.go
+++ b/internal/interfaces/controller/azuredevops_controller.go
@@ -437,16 +437,19 @@ func (r *AzureDevOpsReconciler) handlePodEvent(ctx context.Context, pod *corev1.
 				}
 
 				// Find agent by name pattern
-				podNameWithoutPrefix := pod.Name
+				podNameWithoutHash := pod.Name
 				if idx := strings.LastIndex(pod.Name, "-"); idx > 0 {
-					podNameWithoutPrefix = pod.Name[:idx]
+					podNameWithoutHash = pod.Name[:idx]
+					if idx2 := strings.LastIndex(podNameWithoutHash, "-"); idx2 > 0 {
+						podNameWithoutHash = podNameWithoutHash[:idx2]
+					}
 				}
 
 				success, failed := 0, 0
 				for _, agent := range agents {
 					// Match agent name with pod name (may need adjustment based on your naming pattern)
-					agentNamePattern := fmt.Sprintf("%s-", podNameWithoutPrefix)
-					if strings.HasPrefix(agent.Name, agentNamePattern) || agent.Name == podNameWithoutPrefix {
+					agentNamePattern := fmt.Sprintf("%s-", podNameWithoutHash)
+					if strings.HasPrefix(agent.Name, agentNamePattern) || agent.Name == podNameWithoutHash {
 						// Disable agent first
 						if agent.Enabled {
 							if err := azureDevOpsClient.DisableAgent(ctx, poolID, agent.ID); err != nil {

--- a/internal/interfaces/controller/azuredevops_controller.go
+++ b/internal/interfaces/controller/azuredevops_controller.go
@@ -91,7 +91,7 @@ func (r *AzureDevOpsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			logger.Error(err, "Failed to handle pod event")
 			return ctrl.Result{RequeueAfter: time.Minute}, err
 		}
-		return ctrl.Result{}, nil
+		return ctrl.Result{RequeueAfter: 3 * time.Second}, nil
 	} else if !apierrors.IsNotFound(err) {
 		// Unexpected error
 		logger.Error(err, "Failed to get resource")
@@ -103,7 +103,7 @@ func (r *AzureDevOpsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if err := r.Get(ctxWithTimeout, req.NamespacedName, &cr); err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.V(1).Info("Resource not found, ignoring")
-			return ctrl.Result{}, nil
+			return ctrl.Result{RequeueAfter: 3 * time.Second}, nil
 		}
 		logger.Error(err, "Failed to get resource")
 		return ctrl.Result{}, err
@@ -146,10 +146,10 @@ func (r *AzureDevOpsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			}
 
 			logger.Info("Successfully cleaned up Azure DevOps resources")
-			return ctrl.Result{}, nil
+			return ctrl.Result{RequeueAfter: 3 * time.Second}, nil
 		}
 		// Finalizer already removed, nothing to do
-		return ctrl.Result{}, nil
+		return ctrl.Result{RequeueAfter: 3 * time.Second}, nil
 	}
 	// Add finalizer if it doesn't exist
 	if !controllerutil.ContainsFinalizer(&cr, azuredevops.AzdoFinalizerName) {
@@ -366,7 +366,7 @@ func (r *AzureDevOpsReconciler) deleteExternalAzDOResources(ctx context.Context,
 
 	// Find and disable/delete agents with names that match our pattern
 	agentPrefix := fmt.Sprintf("%s-", cr.Name)
-
+	success, failed := 0, 0
 	for _, agent := range agents {
 		// Check if the agent belongs to this resource by checking name prefix
 		if strings.HasPrefix(agent.Name, agentPrefix) {
@@ -380,6 +380,7 @@ func (r *AzureDevOpsReconciler) deleteExternalAzDOResources(ctx context.Context,
 				if err := client.DisableAgent(ctx, poolID, agent.ID); err != nil {
 					logger.Error(err, "Failed to disable agent", "agentID", agent.ID)
 					// Continue with other agents even if this one fails
+					failed++
 					continue
 				}
 				logger.Info("Successfully disabled agent", "agentID", agent.ID)
@@ -389,14 +390,15 @@ func (r *AzureDevOpsReconciler) deleteExternalAzDOResources(ctx context.Context,
 			if err := client.DeleteAgent(ctx, poolID, agent.ID); err != nil {
 				logger.Error(err, "Failed to delete agent", "agentID", agent.ID)
 				// Continue with other agents even if this one fails
+				failed++
 				continue
 			}
 
 			logger.Info("Successfully deleted agent", "agentID", agent.ID)
+			success++
 		}
 	}
-
-	logger.Info("Azure DevOps resource cleanup completed")
+	logger.Info("Azure DevOps resource cleanup completed", "successfulCleanups", success, "failedCleanups", failed)
 	return nil
 }
 
@@ -455,7 +457,8 @@ func (r *AzureDevOpsReconciler) handlePodEvent(ctx context.Context, pod *corev1.
 
 				for _, agent := range agents {
 					// Match agent name with pod name (may need adjustment based on your naming pattern)
-					if strings.Contains(agent.Name, podNameWithoutPrefix) {
+					agentNamePattern := fmt.Sprintf("%s-", podNameWithoutPrefix)
+					if strings.HasPrefix(agent.Name, agentNamePattern) || agent.Name == podNameWithoutPrefix {
 						logger.Info("Found matching agent to clean up",
 							"agentID", agent.ID,
 							"agentName", agent.Name)

--- a/internal/interfaces/controller/azuredevops_controller.go
+++ b/internal/interfaces/controller/azuredevops_controller.go
@@ -9,6 +9,7 @@ import (
 	usecases "fr.simplified/azuredevops/internal/app/usecase"
 	"fr.simplified/azuredevops/internal/infra/azuredevops"
 	"fr.simplified/azuredevops/internal/infra/kubernetes"
+	"go.uber.org/multierr"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -365,6 +366,7 @@ func (r *AzureDevOpsReconciler) deleteExternalAzDOResources(ctx context.Context,
 	// Find and disable/delete agents with names that match our pattern
 	agentPrefix := fmt.Sprintf("%s-", cr.Name)
 	success, failed := 0, 0
+	var failureError error
 	for _, agent := range agents {
 		// Check if the agent belongs to this resource by checking name prefix
 		if strings.HasPrefix(agent.Name, agentPrefix) {
@@ -373,6 +375,7 @@ func (r *AzureDevOpsReconciler) deleteExternalAzDOResources(ctx context.Context,
 				if err := client.DisableAgent(ctx, poolID, agent.ID); err != nil {
 					logger.Error(err, "Failed to disable agent", "agentID", agent.ID)
 					failed++
+					failureError = multierr.Append(failureError, err)
 					continue
 				}
 			}
@@ -381,12 +384,18 @@ func (r *AzureDevOpsReconciler) deleteExternalAzDOResources(ctx context.Context,
 			if err := client.DeleteAgent(ctx, poolID, agent.ID); err != nil {
 				logger.Error(err, "Failed to delete agent", "agentID", agent.ID)
 				failed++
+				failureError = multierr.Append(failureError, err)
 				continue
 			}
 
 			success++
 		}
 	}
+
+	if failed > 0 {
+		return fmt.Errorf("failed to clean up %d Azure DevOps agents: %w", failed, failureError)
+	}
+
 	logger.V(1).Info("Azure DevOps resource cleanup completed", "successfulCleanups", success, "failedCleanups", failed)
 	return nil
 }

--- a/internal/interfaces/controller/azuredevops_controller.go
+++ b/internal/interfaces/controller/azuredevops_controller.go
@@ -78,7 +78,7 @@ func (r *AzureDevOpsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		"name", req.Name,
 		"namespace", req.Namespace,
 	)
-	logger.V(1).Info("Starting reconciliation")
+	logger.V(2).Info("Starting reconciliation")
 
 	// Create a context with configurable timeout
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, r.ReconcileTimeout)
@@ -320,11 +320,10 @@ func (r *AzureDevOpsReconciler) updateStatus(ctx context.Context, cr *agentsv0be
 		// Try to update
 		if err := r.Status().Update(ctx, updatedCR); err != nil {
 			if apierrors.IsConflict(err) && i < 2 {
-				// If it's a conflict and we have retries left, wait and try again
 				time.Sleep(time.Duration(i+1) * 100 * time.Millisecond)
 				continue
 			}
-			logger.V(1).Info("Failed to update AzureDevOps status", "error", err)
+			logger.V(2).Info("Failed to update AzureDevOps status", "error", err) // Change from V(1) to V(2)
 			return
 		}
 		return // Success
@@ -345,7 +344,6 @@ func calculateRequeueInterval(lastFailure *metav1.Time) time.Duration {
 	}
 	return interval
 }
-
 func (r *AzureDevOpsReconciler) deleteExternalAzDOResources(ctx context.Context, cr *agentsv0beta0.AzureDevOps, client azuredevops.Client) error {
 	logger := log.FromContext(ctx).WithValues(
 		"name", cr.Name,
@@ -370,35 +368,26 @@ func (r *AzureDevOpsReconciler) deleteExternalAzDOResources(ctx context.Context,
 	for _, agent := range agents {
 		// Check if the agent belongs to this resource by checking name prefix
 		if strings.HasPrefix(agent.Name, agentPrefix) {
-			logger.Info("Found agent to cleanup",
-				"agentID", agent.ID,
-				"agentName", agent.Name,
-				"agentStatus", agent.Status)
-
 			// Disable agent first
 			if agent.Enabled {
 				if err := client.DisableAgent(ctx, poolID, agent.ID); err != nil {
 					logger.Error(err, "Failed to disable agent", "agentID", agent.ID)
-					// Continue with other agents even if this one fails
 					failed++
 					continue
 				}
-				logger.Info("Successfully disabled agent", "agentID", agent.ID)
 			}
 
 			// Delete agent
 			if err := client.DeleteAgent(ctx, poolID, agent.ID); err != nil {
 				logger.Error(err, "Failed to delete agent", "agentID", agent.ID)
-				// Continue with other agents even if this one fails
 				failed++
 				continue
 			}
 
-			logger.Info("Successfully deleted agent", "agentID", agent.ID)
 			success++
 		}
 	}
-	logger.Info("Azure DevOps resource cleanup completed", "successfulCleanups", success, "failedCleanups", failed)
+	logger.V(1).Info("Azure DevOps resource cleanup completed", "successfulCleanups", success, "failedCleanups", failed)
 	return nil
 }
 
@@ -414,9 +403,7 @@ func (r *AzureDevOpsReconciler) handlePodEvent(ctx context.Context, pod *corev1.
 		// Find the owning AzureDevOps CR
 		for _, ownerRef := range pod.OwnerReferences {
 			if ownerRef.Kind == "AzureDevOps" {
-				logger.Info("Pod is being deleted/completed, cleaning up Azure DevOps agent",
-					"agentName", pod.Name,
-					"ownerCR", ownerRef.Name)
+				logger.V(2).Info("Processing deleted/completed pod")
 
 				// Get the CR
 				cr := agentsv0beta0.AzureDevOps{}
@@ -455,31 +442,32 @@ func (r *AzureDevOpsReconciler) handlePodEvent(ctx context.Context, pod *corev1.
 					podNameWithoutPrefix = pod.Name[:idx]
 				}
 
+				success, failed := 0, 0
 				for _, agent := range agents {
 					// Match agent name with pod name (may need adjustment based on your naming pattern)
 					agentNamePattern := fmt.Sprintf("%s-", podNameWithoutPrefix)
 					if strings.HasPrefix(agent.Name, agentNamePattern) || agent.Name == podNameWithoutPrefix {
-						logger.Info("Found matching agent to clean up",
-							"agentID", agent.ID,
-							"agentName", agent.Name)
-
 						// Disable agent first
 						if agent.Enabled {
 							if err := azureDevOpsClient.DisableAgent(ctx, poolID, agent.ID); err != nil {
 								logger.Error(err, "Failed to disable agent", "agentID", agent.ID)
+								failed++
 								continue
 							}
-							logger.Info("Successfully disabled agent", "agentID", agent.ID)
 						}
 
 						// Delete agent
 						if err := azureDevOpsClient.DeleteAgent(ctx, poolID, agent.ID); err != nil {
 							logger.Error(err, "Failed to delete agent", "agentID", agent.ID)
+							failed++
 							continue
 						}
-						logger.Info("Successfully deleted agent", "agentID", agent.ID)
+
+						success++
 					}
 				}
+
+				logger.V(2).Info("Cleanup completed", "successfulCleanups", success, "failedCleanups", failed)
 
 				return nil
 			}

--- a/internal/interfaces/controller/azuredevops_controller.go
+++ b/internal/interfaces/controller/azuredevops_controller.go
@@ -63,6 +63,7 @@ func (r *AzureDevOpsReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&agentsv0beta0.AzureDevOps{}).
 		Owns(&appsv1.Deployment{}).
+		Owns(&corev1.Pod{}).
 		Complete(r)
 }
 
@@ -82,6 +83,20 @@ func (r *AzureDevOpsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// Create a context with configurable timeout
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, r.ReconcileTimeout)
 	defer cancel()
+
+	var pod corev1.Pod
+	if err := r.Get(ctxWithTimeout, req.NamespacedName, &pod); err == nil {
+		// If we found a pod, handle it
+		if err := r.handlePodEvent(ctxWithTimeout, &pod); err != nil {
+			logger.Error(err, "Failed to handle pod event")
+			return ctrl.Result{RequeueAfter: time.Minute}, err
+		}
+		return ctrl.Result{}, nil
+	} else if !apierrors.IsNotFound(err) {
+		// Unexpected error
+		logger.Error(err, "Failed to get resource")
+		return ctrl.Result{}, err
+	}
 
 	// Récupérer le CR
 	var cr agentsv0beta0.AzureDevOps
@@ -382,5 +397,91 @@ func (r *AzureDevOpsReconciler) deleteExternalAzDOResources(ctx context.Context,
 	}
 
 	logger.Info("Azure DevOps resource cleanup completed")
+	return nil
+}
+
+// handlePodEvent processes pod deletions and removes the corresponding Azure DevOps agents
+func (r *AzureDevOpsReconciler) handlePodEvent(ctx context.Context, pod *corev1.Pod) error {
+	logger := log.FromContext(ctx).WithValues(
+		"pod", pod.Name,
+		"namespace", pod.Namespace,
+	)
+
+	// Check if pod is being deleted or has failed/succeeded
+	if pod.DeletionTimestamp != nil || pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded {
+		// Find the owning AzureDevOps CR
+		for _, ownerRef := range pod.OwnerReferences {
+			if ownerRef.Kind == "AzureDevOps" {
+				logger.Info("Pod is being deleted/completed, cleaning up Azure DevOps agent",
+					"agentName", pod.Name,
+					"ownerCR", ownerRef.Name)
+
+				// Get the CR
+				cr := agentsv0beta0.AzureDevOps{}
+				if err := r.Get(ctx, types.NamespacedName{Name: ownerRef.Name, Namespace: pod.Namespace}, &cr); err != nil {
+					logger.Error(err, "Failed to get AzureDevOps CR")
+					return err
+				}
+
+				// Get PAT token
+				patToken, err := r.getPATToken(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}}, cr.Spec.PatSecretRef)
+				if err != nil {
+					logger.Error(err, "Failed to get PAT token")
+					return err
+				}
+
+				// Create Azure DevOps client
+				azureDevOpsClient := azuredevops.NewAzureDevOpsClient(patToken, cr.Spec.OrgURL, cr.Spec.Project)
+
+				// Get pool ID
+				poolID, err := azureDevOpsClient.GetPoolIDByName(ctx, cr.Spec.PoolName)
+				if err != nil {
+					logger.Error(err, "Failed to get pool ID")
+					return err
+				}
+
+				// Get all agents
+				agents, err := azureDevOpsClient.GetAgentsInPool(ctx, poolID)
+				if err != nil {
+					logger.Error(err, "Failed to get agents in pool")
+					return err
+				}
+
+				// Find agent by name pattern
+				podNameWithoutPrefix := pod.Name
+				if idx := strings.LastIndex(pod.Name, "-"); idx > 0 {
+					podNameWithoutPrefix = pod.Name[:idx]
+				}
+
+				for _, agent := range agents {
+					// Match agent name with pod name (may need adjustment based on your naming pattern)
+					if strings.Contains(agent.Name, podNameWithoutPrefix) {
+						logger.Info("Found matching agent to clean up",
+							"agentID", agent.ID,
+							"agentName", agent.Name)
+
+						// Disable agent first
+						if agent.Enabled {
+							if err := azureDevOpsClient.DisableAgent(ctx, poolID, agent.ID); err != nil {
+								logger.Error(err, "Failed to disable agent", "agentID", agent.ID)
+								continue
+							}
+							logger.Info("Successfully disabled agent", "agentID", agent.ID)
+						}
+
+						// Delete agent
+						if err := azureDevOpsClient.DeleteAgent(ctx, poolID, agent.ID); err != nil {
+							logger.Error(err, "Failed to delete agent", "agentID", agent.ID)
+							continue
+						}
+						logger.Info("Successfully deleted agent", "agentID", agent.ID)
+					}
+				}
+
+				return nil
+			}
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new configuration options to control the minimum and maximum number of replicas for the Azure DevOps agent, giving users enhanced control over scaling.
	- Added methods for managing agents in Azure DevOps, including retrieving pool IDs, fetching agents, disabling agents, and deleting agents.
	- Implemented functionality for proper cleanup of Azure DevOps resources during resource deletion.
	- Added a new struct to represent agents with relevant fields for better management.

- **Refactor**
	- Improved the autoscaling mechanism to dynamically adjust replica counts based on defined boundaries, ensuring optimal performance and robust error handling.
	- Enhanced command execution behavior for the Azure DevOps agent container to run in a one-time mode.
	- Updated image configuration for the Azure DevOps operator to reflect a new repository and version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->